### PR TITLE
ルート登録画面の作成完了（動くレベルで）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'dotenv-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
@@ -196,6 +200,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  dotenv-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mysql2

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=please confirm kato" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATAz-WoDt8oJiahKPcbqgMMOCtihvSJAQ" async defer></script>
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,6 @@
 
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATAz-WoDt8oJiahKPcbqgMMOCtihvSJAQ" async defer></script>
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   </head>

--- a/app/views/touring_routes/_form.html.erb
+++ b/app/views/touring_routes/_form.html.erb
@@ -32,8 +32,8 @@
   </div>
 
   <div class="field">
-    <%= radio_button_tag(:lanlon, "start") %>
-    <%= label_tag(:latlon_start, "出発地点") %>
+    <%= radio_button_tag(:RadioGroup, "start") %>
+    <%= label_tag(:RadioGroup_start, "出発地点") %>
     <%= form.label :start_lat %>
     <%= form.text_field :start_lat %>
   </div>
@@ -44,8 +44,8 @@
   </div>
 
   <div class="field">
-    <%= radio_button_tag(:lanlon, "end") %>
-    <%= label_tag(:latlon_end, "目的地") %>
+    <%= radio_button_tag(:RadioGroup, "end") %>
+    <%= label_tag(:RadioGroup_end, "目的地") %>
     <%= form.label :end_lat %>
     <%= form.text_field :end_lat %>
   </div>
@@ -56,8 +56,8 @@
   </div>
 
   <div class="field">
-    <%= radio_button_tag(:lanlon, "wp1") %>
-    <%= label_tag(:latlon_wp1, "経由地1") %>
+    <%= radio_button_tag(:RadioGroup, "wp1") %>
+    <%= label_tag(:RadioGroup_wp1, "経由地1") %>
     <%= form.label :wp1_lat %>
     <%= form.text_field :wp1_lat %>
   </div>
@@ -68,8 +68,8 @@
   </div>
 
   <div class="field">
-    <%= radio_button_tag(:lanlon, "wp2") %>
-    <%= label_tag(:latlon_wp2, "経由地2") %><%= form.label :wp2_lat %>
+    <%= radio_button_tag(:RadioGroup, "wp2") %>
+    <%= label_tag(:RadioGroup_wp2, "経由地2") %><%= form.label :wp2_lat %>
     <%= form.text_field :wp2_lat %>
   </div>
 
@@ -79,8 +79,8 @@
   </div>
 
   <div class="field">
-    <%= radio_button_tag(:lanlon, "wp3") %>
-    <%= label_tag(:latlon_wp3, "経由地3") %>
+    <%= radio_button_tag(:RadioGroup, "wp3") %>
+    <%= label_tag(:RadioGroup_wp3, "経由地3") %>
     <%= form.label :wp3_lat %>
     <%= form.text_field :wp3_lat %>
   </div>

--- a/app/views/touring_routes/_form.html.erb
+++ b/app/views/touring_routes/_form.html.erb
@@ -32,6 +32,8 @@
   </div>
 
   <div class="field">
+    <%= radio_button_tag(:lanlon, "start") %>
+    <%= label_tag(:latlon_start, "出発地点") %>
     <%= form.label :start_lat %>
     <%= form.text_field :start_lat %>
   </div>
@@ -42,6 +44,8 @@
   </div>
 
   <div class="field">
+    <%= radio_button_tag(:lanlon, "end") %>
+    <%= label_tag(:latlon_end, "目的地") %>
     <%= form.label :end_lat %>
     <%= form.text_field :end_lat %>
   </div>
@@ -52,6 +56,8 @@
   </div>
 
   <div class="field">
+    <%= radio_button_tag(:lanlon, "wp1") %>
+    <%= label_tag(:latlon_wp1, "経由地1") %>
     <%= form.label :wp1_lat %>
     <%= form.text_field :wp1_lat %>
   </div>
@@ -62,7 +68,8 @@
   </div>
 
   <div class="field">
-    <%= form.label :wp2_lat %>
+    <%= radio_button_tag(:lanlon, "wp2") %>
+    <%= label_tag(:latlon_wp2, "経由地2") %><%= form.label :wp2_lat %>
     <%= form.text_field :wp2_lat %>
   </div>
 
@@ -72,6 +79,8 @@
   </div>
 
   <div class="field">
+    <%= radio_button_tag(:lanlon, "wp3") %>
+    <%= label_tag(:latlon_wp3, "経由地3") %>
     <%= form.label :wp3_lat %>
     <%= form.text_field :wp3_lat %>
   </div>

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -7,13 +7,12 @@
 <%= link_to 'Back', touring_routes_path %>
 
 <script>
-$(function() {
     function initMap() {
 
       // マップの初期化
         var map = new google.maps.Map(document.getElementById('map'), {
           zoom: 9,
-          center: {lat: 36.38992, lng: 139.06065}
+          center: {lat: 33.31478181566308, lng: 130.50810970427096}
         });
  
       // ツーリングルートのオブジェクト定義
@@ -22,9 +21,6 @@ $(function() {
         // クリックイベントを追加
         map.addListener('click', function(e) {
           getClickLatLng(e.latLng, map);
-
-          # let json = JSON.stringify( routes );
-
 
         // チェックボタンの状態値でデータを表示
           let radio_btns = document.getElementsByName("RadioGroup");
@@ -84,5 +80,6 @@ $(function() {
   
       map.panTo(lat_lng);
     }
-    });
+
   </script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATAz-WoDt8oJiahKPcbqgMMOCtihvSJAQ&callback=initMap" async defer></script>

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -2,4 +2,97 @@
 
 <%= render 'form', touring_route: @touring_route %>
 
+<div id="map" style=" width: 800px; height: 500px"></div>
+
 <%= link_to 'Back', touring_routes_path %>
+
+  <script>
+    function initMap() {
+
+      // マップの初期化
+        var map = new google.maps.Map(document.getElementById('map'), {
+          zoom: 9,
+          center: {lat: 36.38992, lng: 139.06065}
+        });
+ 
+      // ツーリングルートのオブジェクト定義
+        let routes ={};
+
+        // クリックイベントを追加
+        map.addListener('click', function(e) {
+          getClickLatLng(e.latLng, map);
+
+          # let json = JSON.stringify( routes );
+
+
+        // チェックボタンの状態値でデータを表示
+          let radio_btns = document.getElementsByName("RadioGroup1");
+
+          for(var i = 0; i < radio_btns.length; i++){
+          
+            if(radio_btns[i].checked) {
+              switch(i){
+                case 0:
+                  document.getElementById('lat1').textContent = e.latLng.lat();
+                  routes.start_lat = e.latLng.lat();
+                  document.getElementById('lng1').textContent = e.latLng.lng();
+                  routes.start_lng = e.latLng.lng();
+                  break;
+                case 1:
+                  document.getElementById('lat2').textContent = e.latLng.lat();
+                  routes.end_lat = e.latLng.lat();
+                  document.getElementById('lng2').textContent = e.latLng.lng();
+                  routes.end_lng = e.latLng.lng();
+                  break;
+                case 2:
+                  document.getElementById('lat3').textContent = e.latLng.lat();
+                  routes.wp1_lat = e.latLng.lat();
+                  document.getElementById('lng3').textContent = e.latLng.lng();
+                  routes.wp1_lng = e.latLng.lng();
+                  break;
+                case 3:
+                  document.getElementById('lat4').textContent = e.latLng.lat();
+                  routes.wp2_lat = e.latLng.lat();
+                  document.getElementById('lng4').textContent = e.latLng.lng();
+                  routes.wp2_lng = e.latLng.lng();
+                  break;
+                case 4:
+                  document.getElementById('lat5').textContent = e.latLng.lat();
+                  routes.wp3 = e.latLng.lat();
+                  document.getElementById('lng5').textContent = e.latLng.lng();
+                  routes.wp3_lng = e.latLng.lng();
+                  break;
+                default:
+                  console.log(i,"check_btn error");
+                break;
+              }
+            }
+          } 
+      });
+    }
+
+    function getClickLatLng(lat_lng, map) {
+
+      // 座標を表示
+      // document.getElementById('lat').textContent = lat_lng.lat();
+      // document.getElementById('lng').textContent = lat_lng.lng();
+
+    
+
+      // 座標履歴を表示 by kato
+      // let historyHtml = "<p>lat:" + lat_lng.lat() + " lng:" +lat_lng.lng() + "</p>";
+      // $("#ex").append(historyHtml) ;     
+      
+
+
+      // マーカーを設置
+      var marker = new google.maps.Marker({
+        position: lat_lng,
+        map: map
+      });
+
+      // 座標の中心をずらす
+  
+      map.panTo(lat_lng);
+    }
+  </script>

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -6,7 +6,8 @@
 
 <%= link_to 'Back', touring_routes_path %>
 
-  <script>
+<script>
+$(function() {
     function initMap() {
 
       // マップの初期化
@@ -26,40 +27,40 @@
 
 
         // チェックボタンの状態値でデータを表示
-          let radio_btns = document.getElementsByName("RadioGroup1");
+          let radio_btns = document.getElementsByName("RadioGroup");
 
           for(var i = 0; i < radio_btns.length; i++){
           
             if(radio_btns[i].checked) {
               switch(i){
                 case 0:
-                  document.getElementById('lat1').textContent = e.latLng.lat();
+                  $('#touring_route_start_lat').val(e.latLng.lat());
                   routes.start_lat = e.latLng.lat();
-                  document.getElementById('lng1').textContent = e.latLng.lng();
+                  $('#touring_route_start_lon').val(e.latLng.lng());
                   routes.start_lng = e.latLng.lng();
                   break;
                 case 1:
-                  document.getElementById('lat2').textContent = e.latLng.lat();
+                  $('#touring_route_end_lat').val(e.latLng.lat());
                   routes.end_lat = e.latLng.lat();
-                  document.getElementById('lng2').textContent = e.latLng.lng();
+                  $('#touring_route_end_lon').val(e.latLng.lng());
                   routes.end_lng = e.latLng.lng();
                   break;
                 case 2:
-                  document.getElementById('lat3').textContent = e.latLng.lat();
+                  $('#touring_route_wp1_lat').val(e.latLng.lat());
                   routes.wp1_lat = e.latLng.lat();
-                  document.getElementById('lng3').textContent = e.latLng.lng();
+                  $('#touring_route_wp1_lon').val(e.latLng.lng());
                   routes.wp1_lng = e.latLng.lng();
                   break;
                 case 3:
-                  document.getElementById('lat4').textContent = e.latLng.lat();
+                  $('#touring_route_wp2_lat').val(e.latLng.lat());
                   routes.wp2_lat = e.latLng.lat();
-                  document.getElementById('lng4').textContent = e.latLng.lng();
+                  $('#touring_route_wp2_lon').val(e.latLng.lng());
                   routes.wp2_lng = e.latLng.lng();
                   break;
                 case 4:
-                  document.getElementById('lat5').textContent = e.latLng.lat();
+                  $('#touring_route_wp3_lat').val(e.latLng.lat());
                   routes.wp3 = e.latLng.lat();
-                  document.getElementById('lng5').textContent = e.latLng.lng();
+                  $('#touring_route_wp3_lon').val(e.latLng.lng());
                   routes.wp3_lng = e.latLng.lng();
                   break;
                 default:
@@ -73,18 +74,6 @@
 
     function getClickLatLng(lat_lng, map) {
 
-      // 座標を表示
-      // document.getElementById('lat').textContent = lat_lng.lat();
-      // document.getElementById('lng').textContent = lat_lng.lng();
-
-    
-
-      // 座標履歴を表示 by kato
-      // let historyHtml = "<p>lat:" + lat_lng.lat() + " lng:" +lat_lng.lng() + "</p>";
-      // $("#ex").append(historyHtml) ;     
-      
-
-
       // マーカーを設置
       var marker = new google.maps.Marker({
         position: lat_lng,
@@ -95,4 +84,5 @@
   
       map.panTo(lat_lng);
     }
+    });
   </script>

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -82,4 +82,4 @@
     }
 
   </script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATAz-WoDt8oJiahKPcbqgMMOCtihvSJAQ&callback=initMap" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['API_KEY']%>&callback=initMap" async defer></script>

--- a/app/views/touring_routes/show.html.erb
+++ b/app/views/touring_routes/show.html.erb
@@ -119,7 +119,7 @@ function initMap(routes) {
             { location: new google.maps.LatLng(routes.data.wp2_lat,routes.data.wp2_lon) },
             { location: new google.maps.LatLng(routes.data.wp3_lat,routes.data.wp3_lon) },
         ],
-        travelMode: google.maps.DirectionsTravelMode.WALKING, // 交通手段(歩行。DRIVINGの場合は車)
+        travelMode: google.maps.DirectionsTravelMode.DRIVING, // 交通手段(DRIVINGの場合は車)
     };
 
     // マップの中心計算
@@ -146,4 +146,4 @@ function initMap(routes) {
     });
 }
 </script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATAz-WoDt8oJiahKPcbqgMMOCtihvSJAQ" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['API_KEY']%>" async defer></script>

--- a/app/views/touring_routes/show.html.erb
+++ b/app/views/touring_routes/show.html.erb
@@ -148,3 +148,4 @@ function initMap(routes) {
     });
 }
 </script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATAz-WoDt8oJiahKPcbqgMMOCtihvSJAQ" async defer></script>

--- a/app/views/touring_routes/show.html.erb
+++ b/app/views/touring_routes/show.html.erb
@@ -101,7 +101,6 @@
 <script>
 (async() => {
   // json を読み込む
-  console.log("json axios start!")
   const res = await axios.get('/touring_routes/<%= @touring_route.id %>.json').catch(() => {
     console.error('データの取得に失敗')
     return null
@@ -111,7 +110,6 @@
 })()
 
 function initMap(routes) {
-    console.table(routes)
     // ルート検索の条件
     var request = {
         origin: new google.maps.LatLng(routes.data.start_lat,routes.data.start_lon), // 出発地


### PR DESCRIPTION
ルート登録画面をMAP対応にしました。とりあえず、座標とクリックしてデータとして反映できます。
実行にはAPI-Keyが必要です。
.env環境変数として記入すればlocalhostでも動きます。
GoogleのAPI-Keyは各自の所有の物でテストするか、持ってなければ私のを教えます。
[このQiita](https://qiita.com/hayatokunn/items/d8a9e9deec33e9022b4f)で設定がわかります
明日、マージした後、マネクラ環境にデプロイして火曜には皆でテストしてもらう予定です。
あと1週間なのでブラッシュアップしていきたいと思います。