### PR TITLE
ルート登録のマーカーの限定化とラベル追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-
+.mc-rails.yml
 /.env

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -59,7 +59,7 @@ input{
   box-sizing: border-box;
 }
 .field{
-  margin-top: 1.6rem;
+  margin-top: 1.2rem;
 }
 
  header{

--- a/app/views/touring_routes/_form.html.erb
+++ b/app/views/touring_routes/_form.html.erb
@@ -39,7 +39,7 @@
           <%= radio_button_tag(:RadioGroup, "start",{:checked => true}) %>
           <%= label_tag(:RadioGroup_start, "出発地点") %>
         </div>
-        <div class="flex">
+        <div class="none">
           <%= form.label :start_lat %>
           <%= form.text_field :start_lat %>
           <%= form.label :start_lon %>
@@ -53,7 +53,7 @@
           <%= radio_button_tag(:RadioGroup, "end") %>
           <%= label_tag(:RadioGroup_end, "目的地") %>
         </div>
-        <div class="flex">
+        <div class="none">
           <%= form.label :end_lat %>
           <%= form.text_field :end_lat %>
           <%= form.label :end_lon %>
@@ -67,7 +67,7 @@
           <%= radio_button_tag(:RadioGroup, "wp1") %>
           <%= label_tag(:RadioGroup_wp1, "経由地1") %>
         </div>
-        <div class="flex">
+        <div class="none">
           <%= form.label :wp1_lat %>
           <%= form.text_field :wp1_lat %>
           <%= form.label :wp1_lon %>
@@ -80,7 +80,7 @@
           <%= radio_button_tag(:RadioGroup, "wp2") %>
           <%= label_tag(:RadioGroup_wp2, "経由地2") %>
         </div>
-        <div class="flex">
+        <div class="none">
           <%= form.label :wp2_lat %>
           <%= form.text_field :wp2_lat %>
           <%= form.label :wp2_lon %>
@@ -94,7 +94,7 @@
           <%= radio_button_tag(:RadioGroup, "wp3") %>
           <%= label_tag(:RadioGroup_wp3, "経由地3") %>
         </div>
-        <div class="flex">
+        <div class="none">
           <%= form.label :wp3_lat %>
           <%= form.text_field :wp3_lat %>
           <%= form.label :wp3_lon %>

--- a/app/views/touring_routes/_form.html.erb
+++ b/app/views/touring_routes/_form.html.erb
@@ -36,7 +36,7 @@
     <li>
       <div class="field">
         <div class="flex">
-          <%= radio_button_tag(:RadioGroup, "start") %>
+          <%= radio_button_tag(:RadioGroup, "start",{:checked => true}) %>
           <%= label_tag(:RadioGroup_start, "出発地点") %>
         </div>
         <div class="flex">

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -20,13 +20,8 @@
         // クリックイベントを追加
         map.addListener('click', function(e) {
 
-
-        // getClickLatLng(e.latLng, map);
         // マーカーを設置
-        var marker = new google.maps.Marker({
-        position: e.latLng,
-        map: map
-        });
+        let marker = getClickLatLng(e.latLng, map);
 
         // チェックボタンの状態値でデータを表示
           let radio_btns = document.getElementsByName("RadioGroup");
@@ -74,16 +69,16 @@
       });
     }
 
-    // function getClickLatLng(lat_lng, map) {
-    //   // マーカーを設置
-    //   var marker = new google.maps.Marker({
-    //     position: lat_lng,
-    //     map: map
-    //   });
-
-      // 座標の中心をずらす
-      // map.panTo(lat_lng);
-    // }
+    function getClickLatLng(lat_lng, map) {
+      // マーカーを設置
+      var marker = new google.maps.Marker({
+        position: lat_lng,
+        map: map
+      });
+      return marker ;
+      座標の中心をずらす
+      map.panTo(lat_lng);
+    }
 
     function deleteMarkers(marker_d) {
 		  if(marker_d != null){

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -14,13 +14,19 @@
           zoom: 9,
           center: {lat: 33.31478181566308, lng: 130.50810970427096}
         });
- 
+
       // ツーリングルートのオブジェクト定義
         let routes ={};
-
         // クリックイベントを追加
         map.addListener('click', function(e) {
-          getClickLatLng(e.latLng, map);
+
+
+        // getClickLatLng(e.latLng, map);
+        // マーカーを設置
+        var marker = new google.maps.Marker({
+        position: e.latLng,
+        map: map
+        });
 
         // チェックボタンの状態値でデータを表示
           let radio_btns = document.getElementsByName("RadioGroup");
@@ -30,34 +36,34 @@
             if(radio_btns[i].checked) {
               switch(i){
                 case 0:
+                  deleteMarkers(routes.start);
+                  routes.start = marker;
                   $('#touring_route_start_lat').val(e.latLng.lat());
-                  routes.start_lat = e.latLng.lat();
                   $('#touring_route_start_lon').val(e.latLng.lng());
-                  routes.start_lng = e.latLng.lng();
                   break;
                 case 1:
+                  deleteMarkers(routes.end);
+                  routes.end = marker;
                   $('#touring_route_end_lat').val(e.latLng.lat());
-                  routes.end_lat = e.latLng.lat();
                   $('#touring_route_end_lon').val(e.latLng.lng());
-                  routes.end_lng = e.latLng.lng();
                   break;
                 case 2:
+                  deleteMarkers(routes.wp1);
+                  routes.wp1 = marker;
                   $('#touring_route_wp1_lat').val(e.latLng.lat());
-                  routes.wp1_lat = e.latLng.lat();
                   $('#touring_route_wp1_lon').val(e.latLng.lng());
-                  routes.wp1_lng = e.latLng.lng();
                   break;
                 case 3:
+                  deleteMarkers(routes.wp2);
+                  routes.wp2 = marker;
                   $('#touring_route_wp2_lat').val(e.latLng.lat());
-                  routes.wp2_lat = e.latLng.lat();
                   $('#touring_route_wp2_lon').val(e.latLng.lng());
-                  routes.wp2_lng = e.latLng.lng();
                   break;
                 case 4:
+                  deleteMarkers(routes.wp3);
+                  routes.wp3 = marker;
                   $('#touring_route_wp3_lat').val(e.latLng.lat());
-                  routes.wp3 = e.latLng.lat();
                   $('#touring_route_wp3_lon').val(e.latLng.lng());
-                  routes.wp3_lng = e.latLng.lng();
                   break;
                 default:
                   console.log(i,"check_btn error");
@@ -68,18 +74,23 @@
       });
     }
 
-    function getClickLatLng(lat_lng, map) {
-
-      // マーカーを設置
-      var marker = new google.maps.Marker({
-        position: lat_lng,
-        map: map
-      });
+    // function getClickLatLng(lat_lng, map) {
+    //   // マーカーを設置
+    //   var marker = new google.maps.Marker({
+    //     position: lat_lng,
+    //     map: map
+    //   });
 
       // 座標の中心をずらす
-  
-      map.panTo(lat_lng);
-    }
+      // map.panTo(lat_lng);
+    // }
+
+    function deleteMarkers(marker_d) {
+		  if(marker_d != null){
+		    marker_d.setMap(null);
+		  }
+		  marker_d = null;
+	}
 
   </script>
     <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['API_KEY']%>&callback=initMap" async defer></script>

--- a/app/views/touring_routes/new.html.erb
+++ b/app/views/touring_routes/new.html.erb
@@ -20,10 +20,7 @@
         // クリックイベントを追加
         map.addListener('click', function(e) {
 
-        // マーカーを設置
-        let marker = getClickLatLng(e.latLng, map);
-
-        // チェックボタンの状態値でデータを表示
+        // 座標ラジオボタンの状態値でマーカーを区別
           let radio_btns = document.getElementsByName("RadioGroup");
 
           for(var i = 0; i < radio_btns.length; i++){
@@ -32,31 +29,36 @@
               switch(i){
                 case 0:
                   deleteMarkers(routes.start);
-                  routes.start = marker;
+                  let marker_start = getClickLatLng(e.latLng, map,"S"); // マーカーを設置
+                  routes.start = marker_start;
                   $('#touring_route_start_lat').val(e.latLng.lat());
                   $('#touring_route_start_lon').val(e.latLng.lng());
                   break;
                 case 1:
                   deleteMarkers(routes.end);
-                  routes.end = marker;
+                  let marker_end = getClickLatLng(e.latLng, map,"E"); // マーカーを設置
+                  routes.end = marker_end;
                   $('#touring_route_end_lat').val(e.latLng.lat());
                   $('#touring_route_end_lon').val(e.latLng.lng());
                   break;
                 case 2:
                   deleteMarkers(routes.wp1);
-                  routes.wp1 = marker;
+                  let marker_wp1 = getClickLatLng(e.latLng, map,"1"); // マーカーを設置
+                  routes.wp1 = marker_wp1;
                   $('#touring_route_wp1_lat').val(e.latLng.lat());
                   $('#touring_route_wp1_lon').val(e.latLng.lng());
                   break;
                 case 3:
                   deleteMarkers(routes.wp2);
-                  routes.wp2 = marker;
+                  let marker_wp2 = getClickLatLng(e.latLng, map,"2"); // マーカーを設置
+                  routes.wp2 = marker_wp2;
                   $('#touring_route_wp2_lat').val(e.latLng.lat());
                   $('#touring_route_wp2_lon').val(e.latLng.lng());
                   break;
                 case 4:
                   deleteMarkers(routes.wp3);
-                  routes.wp3 = marker;
+                  let marker_wp3 = getClickLatLng(e.latLng, map,"3"); // マーカーを設置
+                  routes.wp3 = marker_wp3;
                   $('#touring_route_wp3_lat').val(e.latLng.lat());
                   $('#touring_route_wp3_lon').val(e.latLng.lng());
                   break;
@@ -69,11 +71,18 @@
       });
     }
 
-    function getClickLatLng(lat_lng, map) {
+    function getClickLatLng(lat_lng, map,char) {
       // マーカーを設置
       var marker = new google.maps.Marker({
         position: lat_lng,
-        map: map
+        map: map,
+         label: {
+       text: char,         //ラベル文字
+       color: '#fff',          //ラベル文字の色
+       fontFamily: 'sans-serif',  //フォント 
+       fontWeight: 'bold',        //フォントの太さ 
+       fontSize: '14px'           //フォントのサイズ 
+        } 
       });
       return marker ;
       座標の中心をずらす

--- a/app/views/touring_routes/show.html.erb
+++ b/app/views/touring_routes/show.html.erb
@@ -90,7 +90,6 @@
         <%= render 'comments/form', comment: @comment %>
          <% @touring_route.comments.each do |comment| %>
         <p>
-          <%= comment.id %> <span>:</span>
           <%= comment.comment %>
         </p>
       <% end %>

--- a/app/views/touring_routes/show.html.erb
+++ b/app/views/touring_routes/show.html.erb
@@ -122,10 +122,6 @@
 function initMap(routes) {
     // ルート検索の条件
 
-    console.log("wp1",routes.data.wp1_lat,routes.data.wp1_lon)
-    console.log("wp2",routes.data.wp2_lat,routes.data.wp2_lon)
-    console.log("wp4",routes.data.wp3_lat,routes.data.wp3_lon)
-
     let way_points = []
     if (routes.data.wp1_lat!== null) {
         let locations = {location: new google.maps.LatLng(routes.data.wp1_lat,routes.data.wp1_lon)}


### PR DESCRIPTION
ルート登録で、座標の再設定時には前のマーカーを削除しました。
また、S,E,1,2,3,のラベルをつけてマーカー位置をわかりやすくしました。

これも、問題なければ先にマージします。
